### PR TITLE
updates info in page footer.

### DIFF
--- a/src/Dtdb/BuilderBundle/Resources/views/layout.html.twig
+++ b/src/Dtdb/BuilderBundle/Resources/views/layout.html.twig
@@ -126,7 +126,6 @@ ga('send', 'pageview');
 
     <ul class="list-inline">
     <li><a href="{{ path('cards_about') }}">About</a></li>
-    <li><a href="{{ path('cards_changelog') }}">Change Log</a></li>
     <li><a href="javascript:localStorage.clear()">Clear data</a></li>
     </ul>
 
@@ -134,15 +133,11 @@ ga('send', 'pageview');
       Designed and built by <a href="//twitter.com/alsciende">@alsciende</a>. dtdb.co Creator/Maintainer Emeritus <a href="//twitter.com/platypusDT">@platypusDT</a>.
     </p>
     <p>
-      Maintained by <a href="mailto:admin@dtdb.co">Blargg</a>.
+      Maintained by <a href="https://github.com/townteki" target="_blank">Team Townsquare</a>.
     </p>
     <p>
-      Bug reports and Feature Requests on <a href="https://bitbucket.org/Blargg/dtdb/issues?status=new&status=open" target="_blank">BitBucket</a>
+      Bug reports and Feature Requests on <a href="https://github.com/townteki/dtdb/issues" target="_blank">GitHub</a>
     </p>
-    <p>
-      DoomtownDB is supported by the community to stay ad-free. <a href="https://paypal.me/Blargg">Donate here.</a>
-	</p>
-
 
     <p style="color:#333">
     Doomtown: Reloaded and Deadlands copyright <a href="//peginc.com"><img src="{{  asset('/web/bundles/dtdbbuilder/images/pinnacle.png') }}" width="143" height="40" alt="Pinnacle Entertainment Group"></a>.


### PR DESCRIPTION
- removes link to (outdated) Change Log page
- updates maintainer info
- replaces issue tracker link from BitBucket to GitHub
- removes donation blurb and link

fixes https://github.com/townteki/dtdb/issues/3

before:

![image](https://user-images.githubusercontent.com/1410427/150622547-ad4f4359-3591-4b10-a84d-668132291a96.png)


after:

![image](https://user-images.githubusercontent.com/1410427/150622569-5f38d2b0-df27-4dd5-90cc-b20ea5bef857.png)

